### PR TITLE
Add confirmation dialog before installing or uninstalling

### DIFF
--- a/src/UI/Compiler.hs
+++ b/src/UI/Compiler.hs
@@ -7,8 +7,8 @@ import GI.Gtk qualified as Gtk
 
 import UI.Install
 
-getGHCVersions :: Adw.ToastOverlay -> IO [Adw.ActionRow]
-getGHCVersions toastOverlay = traverse (toActionRow toastOverlay) compilerList
+getGHCVersions :: Adw.ToastOverlay -> Adw.ApplicationWindow -> IO [Adw.ActionRow]
+getGHCVersions toastOverlay app = traverse (toActionRow toastOverlay app "GHC") compilerList
   where
     compilerList =
       [ "9.4.3 (latest)"
@@ -17,36 +17,36 @@ getGHCVersions toastOverlay = traverse (toActionRow toastOverlay) compilerList
       , "8.10.7"
       ]
 
-getCabalVersions :: Adw.ToastOverlay -> IO [Adw.ActionRow]
-getCabalVersions toastOverlay = traverse (toActionRow toastOverlay) cabalVersions
+getCabalVersions :: Adw.ToastOverlay -> Adw.ApplicationWindow -> IO [Adw.ActionRow]
+getCabalVersions toastOverlay app = traverse (toActionRow toastOverlay app "Cabal") cabalVersions
   where
     cabalVersions =
       [ "3.8.1.0 (latest)"
       , "3.6.2.0"
       ]
 
-getHLSVersions :: Adw.ToastOverlay -> IO [Adw.ActionRow]
-getHLSVersions toastOverlay = traverse (toActionRow toastOverlay) hlsVersions
+getHLSVersions :: Adw.ToastOverlay -> Adw.ApplicationWindow -> IO [Adw.ActionRow]
+getHLSVersions toastOverlay app = traverse (toActionRow toastOverlay app "HLS") hlsVersions
   where
     hlsVersions =
       [ "1.8.0.0 (latest)"
       , "1.7.0.0"
       ]
 
-toActionRow :: Adw.ToastOverlay -> Text -> IO Adw.ActionRow
-toActionRow toastOverlay compilerLabel = do
+toActionRow :: Adw.ToastOverlay -> Adw.ApplicationWindow -> Text -> Text -> IO Adw.ActionRow
+toActionRow toastOverlay app toolLabel versionLabel = do
   installButton <-
     new
       Gtk.Switch
       [ #valign := Gtk.AlignCenter
       ]
   on installButton #stateSet $ \state -> do
-    mockInstall toastOverlay state
+    mockInstall installButton toastOverlay app state (toolLabel <> " " <> versionLabel)
 
   actionRow <-
     new
       Adw.ActionRow
-      [ #title := compilerLabel
+      [ #title := versionLabel
       ]
 
   -- setToggle <- new Gtk.CheckButton

--- a/src/UI/Install.hs
+++ b/src/UI/Install.hs
@@ -1,31 +1,57 @@
-{-# LANGUAGE ImplicitParams #-}
-
 module UI.Install where
 
+import Control.Monad (when)
 import Data.GI.Base
+import Data.Text (Text)
 import GI.Adw qualified as Adw
 import GI.Gtk qualified as Gtk
 
-mockInstall :: (?self :: Gtk.Switch) => Adw.ToastOverlay -> Bool -> IO Bool
-mockInstall toastOverlay state = do
-  if state
-    then do
-      notificationToast <-
-        new
-          Adw.Toast
-          [ #title := "Installing…"
-          , #timeout := 3
-          ]
-      Adw.toastOverlayAddToast toastOverlay notificationToast
-      set ?self [#state := state]
-      pure True
-    else do
-      notificationToast <-
-        new
-          Adw.Toast
-          [ #title := "Uninstalling…"
-          , #timeout := 3
-          ]
-      Adw.toastOverlayAddToast toastOverlay notificationToast
-      set ?self [#state := state]
-      pure True
+mockInstall :: Gtk.Switch -> Adw.ToastOverlay -> Adw.ApplicationWindow -> Bool -> Text -> IO Bool
+mockInstall selfSwitch toastOverlay app state toolDescription = do
+  curState <- selfSwitch.getState
+  -- don't handle case when state is being reset: e.g. when 'Cancel'
+  -- button is pressed on message box
+  (True<$) $ when (curState /= state) $ do
+    let stateText = if state then "install" else "uninstall"
+        stateTextUpper = if state then "Install" else "Uninstall"
+        messageText =
+          "Are you sure you want to " <>
+          stateText <> " " <>
+          toolDescription <> "?"
+
+    messageDialog <-
+      Adw.messageDialogNew
+      (Just app)
+      (Just $ "Confirm " <> stateText)
+      (Just messageText)
+    messageDialog.addResponse "cancel" "Cancel"
+    messageDialog.addResponse "doit" stateTextUpper
+
+    messageDialog.setResponseAppearance "doit" Adw.ResponseAppearanceDestructive
+    messageDialog.setDefaultResponse (Just "cancel")
+    messageDialog.setCloseResponse "cancel"
+
+    on messageDialog #response $ \case
+      "doit" ->
+        if state
+          then do
+            notificationToast <-
+              new
+                Adw.Toast
+                [ #title := "Installing…"
+                , #timeout := 3
+                ]
+            Adw.toastOverlayAddToast toastOverlay notificationToast
+            set selfSwitch [#state := state]
+          else do
+            notificationToast <-
+              new
+                Adw.Toast
+                [ #title := "Uninstalling…"
+                , #timeout := 3
+                ]
+            Adw.toastOverlayAddToast toastOverlay notificationToast
+            set selfSwitch [#state := state]
+      _ -> set selfSwitch [#active := not state]  -- reset position
+
+    messageDialog.present

--- a/src/UI/Install.hs
+++ b/src/UI/Install.hs
@@ -11,19 +11,21 @@ mockInstall selfSwitch toastOverlay app state toolDescription = do
   curState <- selfSwitch.getState
   -- don't handle case when state is being reset: e.g. when 'Cancel'
   -- button is pressed on message box
-  (True<$) $ when (curState /= state) $ do
+  (True <$) $ when (curState /= state) $ do
     let stateText = if state then "install" else "uninstall"
         stateTextUpper = if state then "Install" else "Uninstall"
         messageText =
-          "Are you sure you want to " <>
-          stateText <> " " <>
-          toolDescription <> "?"
+          "Are you sure you want to "
+            <> stateText
+            <> " "
+            <> toolDescription
+            <> "?"
 
     messageDialog <-
       Adw.messageDialogNew
-      (Just app)
-      (Just $ "Confirm " <> stateText)
-      (Just messageText)
+        (Just app)
+        (Just $ "Confirm " <> stateText)
+        (Just messageText)
     messageDialog.addResponse "cancel" "Cancel"
     messageDialog.addResponse "doit" stateTextUpper
 
@@ -52,6 +54,5 @@ mockInstall selfSwitch toastOverlay app state toolDescription = do
                 ]
             Adw.toastOverlayAddToast toastOverlay notificationToast
             set selfSwitch [#state := state]
-      _ -> set selfSwitch [#active := not state]  -- reset position
-
+      _ -> set selfSwitch [#active := not state] -- reset position
     messageDialog.present


### PR DESCRIPTION
Fixes #6.

Some nasty subtleties here… in particular, digging through the `gi-gtk` source reveals that the `?self` implicit parameter gets disowned as soon as the callback returns. Thus, in the message box `respond` signal, properties must be set on the original `Gtk.Switch` object, rather than on the `?self` pointer of the outer callback (even though they should in theory be the same), since that pointer gets disowned before the message box signal can run.

Another point is that setting the activity programmatically also triggers the `stateSet` signal. Blocking this is more difficult than it should be, since it requires the handler ID, which can’t be accessed until after the message box has been created! It’s easier to just wrap the whole `mockInstall` function in a conditional, to ensure that the dialog isn’t shown twice.

